### PR TITLE
Trace selection benchmark cost

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
         "@figma/rest-api-spec": "^0.18.0",
-        "@nestia/agent": "^0.1.1",
+        "@nestia/agent": "^0.2.1",
         "@nestia/e2e": "^0.7.0",
         "@nestia/sdk": "^4.5.1",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
@@ -3567,9 +3567,9 @@
       "license": "MIT"
     },
     "node_modules/@nestia/agent": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nestia/agent/-/agent-0.1.1.tgz",
-      "integrity": "sha512-OfDd78V1QOWbB4chJKaEcHKKJ36OIkLkCe76gebb3Wj/EeanPorRr1Uq2GKq+Ghui9GW4QxvJjmcaBx6v4j/yQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@nestia/agent/-/agent-0.2.1.tgz",
+      "integrity": "sha512-afabD5iRZhq0f2d+1RpbmRTUuuuCCK33bF16vqCDFGAvwD5xb611YkZ0snrAhI/TRBiXh+HlE2elDtwuBIHYoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
     "@figma/rest-api-spec": "^0.18.0",
-    "@nestia/agent": "^0.1.1",
+    "@nestia/agent": "^0.2.1",
     "@nestia/e2e": "^0.7.0",
     "@nestia/sdk": "^4.5.1",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/test/benchmark/select/FunctionSelectBenchmarkReporter.ts
+++ b/test/benchmark/select/FunctionSelectBenchmarkReporter.ts
@@ -9,12 +9,14 @@ import { MathUtil } from "../../../src/utils/MathUtil";
 import { IFunctionSelectBenchmarkEvent } from "./IFunctionSelectBenchmarkEvent";
 import { ArrayUtil } from "@nestia/e2e";
 import { ErrorUtil } from "../../../src/utils/ErrorUtil";
+import { INestiaChatTokenUsage } from "@nestia/agent";
 
 export namespace FunctionSelectBenchmarkReporter {
   export interface IProps {
     application: IHttpLlmApplication<"chatgpt">;
     options: IFunctionSelectBenchmarkOptions;
     results: IFunctionSelectBenchmarkResult[];
+    usage: INestiaChatTokenUsage;
   }
 
   export const report = async (props: IProps): Promise<void> => {
@@ -58,6 +60,18 @@ export namespace FunctionSelectBenchmarkReporter {
       `    - Success: ${props.results.map((r) => r.success).reduce((a, b) => a + b, 0)}`,
       `    - Failure: ${props.results.map((r) => r.count - r.success).reduce((a, b) => a + b, 0)}`,
       `    - Average Time: ${MathUtil.round(average).toLocaleString()} ms`,
+      `  - Token Usage:`,
+      `    - Total: ${props.usage.total.toLocaleString()}`,
+      `    - Prompt:`,
+      `      - Total: ${props.usage.prompt.total.toLocaleString()}`,
+      `      - Audio: ${props.usage.prompt.audio.toLocaleString()}`,
+      `      - Cached: ${props.usage.prompt.cached.toLocaleString()}`,
+      `    - Completion:`,
+      `      - Total: ${props.usage.completion.total.toLocaleString()}`,
+      `      - Accepted Prediction: ${props.usage.completion.accepted_prediction.toLocaleString()}`,
+      `      - Audio: ${props.usage.completion.audio.toLocaleString()}`,
+      `      - Reasoning: ${props.usage.completion.reasoning.toLocaleString()}`,
+      `      - Rejected Prediction: ${props.usage.completion.rejected_prediction.toLocaleString()}`,
     ].join("\n");
 
     const table: string = [

--- a/test/benchmark/select/index.ts
+++ b/test/benchmark/select/index.ts
@@ -135,6 +135,7 @@ const main = async (): Promise<void> => {
     application,
     options,
     results,
+    usage: executor.getUsage(),
   });
 };
 main().catch((error) => {


### PR DESCRIPTION
Added token usage reporting.

Looking at the benchmark report, the function selecting benchmark consumes about $382.

  - Arguments:
    - `repeat`: 10
    - `include`: 
    - `exclude`: 
  - Aggregation:
    - Keywords: 150
    - Trial: 1500
    - Success: 1420
    - Failure: 80
    - Average Time: 4,505.77 ms
  - Token Usage:
    - Total: 36,846,257
    - Prompt:
      - Total: 36,488,364
      - Audio: 0
      - Cached: 33,693,696
    - Completion:
      - Total: 36,846,257
      - Accepted Prediction: 0
      - Audio: 0
      - Reasoning: 0
      - Rejected Prediction: 0