### PR TITLE
fix: reddit secret -> refreshToken

### DIFF
--- a/packages/reddit/src/reddit/RedditService.ts
+++ b/packages/reddit/src/reddit/RedditService.ts
@@ -322,7 +322,7 @@ export class RedditService {
       url,
       {
         grant_type: "refresh_token",
-        refresh_token: this.props.secret,
+        refresh_token: this.props.refreshToken,
       },
       {
         headers: {

--- a/packages/reddit/src/structures/IRedditService.ts
+++ b/packages/reddit/src/structures/IRedditService.ts
@@ -6,7 +6,7 @@ export namespace IRedditService {
     /**
      * Reddit Refresh Token.
      */
-    secret: string;
+    refreshToken: string;
 
     /**
      * Reddit Client ID.


### PR DESCRIPTION
This pull request includes changes to the `RedditService` class and the `IRedditService` namespace to improve the consistency and clarity of token management. The most important changes involve renaming the `secret` property to `refreshToken`.

Token management improvements:

* [`packages/reddit/src/reddit/RedditService.ts`](diffhunk://#diff-4910ecb9d91a02e9dd281a94e7c2cfb38fde0b1691b5dfbff9050f71aab86241L325-R325): Updated the `refresh_token` parameter to use `this.props.refreshToken` instead of `this.props.secret`.
* [`packages/reddit/src/structures/IRedditService.ts`](diffhunk://#diff-4534dcdcbe5954cd661ca04a8a33fa3fa8a9242aacca1fa315d1cb88e4962a93L9-R9): Renamed the `secret` property to `refreshToken` in the `IRedditService` interface.# Test before submitting