### PR TITLE
fix: add exports.types to notion package.json

### DIFF
--- a/packages/notion/package.json
+++ b/packages/notion/package.json
@@ -6,7 +6,8 @@
   "exports": {
     "import": "./lib/index.mjs",
     "require": "./lib/index.cjs",
-    "default": "./lib/index.cjs"
+    "default": "./lib/index.cjs",
+    "types": "./lib/index.d.ts"
   },
   "scripts": {
     "prepare": "ts-patch install && typia patch",


### PR DESCRIPTION
## Description
build not work in pnpm.
- Add exports.types to notion's package.json
  - add "./lib/index.d.ts"