### PR TITLE
chore: add publishConfig to package.json

### DIFF
--- a/packages/arxiv_search/package.json
+++ b/packages/arxiv_search/package.json
@@ -76,5 +76,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/aws_s3/package.json
+++ b/packages/aws_s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnlabs/connector-aws-s3",
-  "version": "0.1.505",
+  "version": "0.1.507",
   "description": "",
   "main": "src/index.ts",
   "exports": {
@@ -77,5 +77,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/calendly/package.json
+++ b/packages/calendly/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/career/package.json
+++ b/packages/career/package.json
@@ -74,5 +74,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -80,5 +80,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/dall_e_3/package.json
+++ b/packages/dall_e_3/package.json
@@ -76,5 +76,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/daum_blog/package.json
+++ b/packages/daum_blog/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/daum_cafe/package.json
+++ b/packages/daum_cafe/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/excel/package.json
+++ b/packages/excel/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/figma/package.json
+++ b/packages/figma/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/gmail/package.json
+++ b/packages/gmail/package.json
@@ -76,5 +76,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_ads/package.json
+++ b/packages/google_ads/package.json
@@ -79,5 +79,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_calendar/package.json
+++ b/packages/google_calendar/package.json
@@ -74,5 +74,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_docs/package.json
+++ b/packages/google_docs/package.json
@@ -76,5 +76,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_drive/package.json
+++ b/packages/google_drive/package.json
@@ -80,5 +80,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_flight/package.json
+++ b/packages/google_flight/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_hotel/package.json
+++ b/packages/google_hotel/package.json
@@ -73,5 +73,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_image/package.json
+++ b/packages/google_image/package.json
@@ -73,5 +73,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_map/package.json
+++ b/packages/google_map/package.json
@@ -76,5 +76,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_scholar/package.json
+++ b/packages/google_scholar/package.json
@@ -74,5 +74,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_search/package.json
+++ b/packages/google_search/package.json
@@ -74,5 +74,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_sheet/package.json
+++ b/packages/google_sheet/package.json
@@ -77,5 +77,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_shopping/package.json
+++ b/packages/google_shopping/package.json
@@ -74,5 +74,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_slides/package.json
+++ b/packages/google_slides/package.json
@@ -82,5 +82,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/google_trend/package.json
+++ b/packages/google_trend/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/hancell/package.json
+++ b/packages/hancell/package.json
@@ -80,5 +80,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/imweb/package.json
+++ b/packages/imweb/package.json
@@ -74,5 +74,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/jira/package.json
+++ b/packages/jira/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/kakao_map/package.json
+++ b/packages/kakao_map/package.json
@@ -73,5 +73,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/kakao_navi/package.json
+++ b/packages/kakao_navi/package.json
@@ -73,5 +73,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/kakao_talk/package.json
+++ b/packages/kakao_talk/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/korea_eximbank/package.json
+++ b/packages/korea_eximbank/package.json
@@ -73,5 +73,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/marp/package.json
+++ b/packages/marp/package.json
@@ -77,5 +77,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/naver_blog/package.json
+++ b/packages/naver_blog/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/naver_cafe/package.json
+++ b/packages/naver_cafe/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/naver_news/package.json
+++ b/packages/naver_news/package.json
@@ -74,5 +74,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/notion/package.json
+++ b/packages/notion/package.json
@@ -78,5 +78,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/reddit/package.json
+++ b/packages/reddit/package.json
@@ -76,5 +76,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -79,5 +79,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/short_io/package.json
+++ b/packages/short_io/package.json
@@ -73,5 +73,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -76,5 +76,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/sort/package.json
+++ b/packages/sort/package.json
@@ -72,5 +72,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/stable_diffusion_beta/package.json
+++ b/packages/stable_diffusion_beta/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/sweet_tracker/package.json
+++ b/packages/sweet_tracker/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/typeform/package.json
+++ b/packages/typeform/package.json
@@ -77,5 +77,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/web_crawler/package.json
+++ b/packages/web_crawler/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/x/package.json
+++ b/packages/x/package.json
@@ -75,5 +75,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/youtube_official_search/package.json
+++ b/packages/youtube_official_search/package.json
@@ -76,5 +76,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/youtube_search/package.json
+++ b/packages/youtube_search/package.json
@@ -76,5 +76,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/youtube_transcript/package.json
+++ b/packages/youtube_transcript/package.json
@@ -76,5 +76,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }

--- a/packages/zoom/package.json
+++ b/packages/zoom/package.json
@@ -74,5 +74,8 @@
     "README.md",
     "lib",
     "package.json"
-  ]
+  ],
+  "publishConfig": {
+    "main": "lib/index.js"
+  }
 }


### PR DESCRIPTION
## Description
- Currently, If publish the monorepo packages, `src/index.ts` is included in npm package. so built `.js` file is not recognized. This is fatal error.
- So, add publishConfig to package.json in each monorepo.